### PR TITLE
fix: strip redundant empty strings in result data set

### DIFF
--- a/FP Growth Algorithm.py
+++ b/FP Growth Algorithm.py
@@ -5,7 +5,7 @@ import pyfpgrowth
 # Function to run FP-Growth and display results
 def run_fpgrowth():
     min_support = float(min_support_entry.get())
-    transactions = [line.strip().split(',') for line in transactions_entry.get("1.0", tk.END).split('\n') if line.strip()]
+    transactions = [[item for item in line.strip().split(',') if item != ''] for line in transactions_entry.get("1.0", tk.END).split('\n') if line.strip()]
     patterns = pyfpgrowth.find_frequent_patterns(transactions, min_support)
     sorted_patterns = sorted(patterns.items(), key=lambda x: x[1], reverse=True)
     


### PR DESCRIPTION
### description

Empty strings, which do not represent actual transaction items, persist in the result.

### fix content

using another list reference expression to filter out empty strings which do not represent actual items.

### result

The cleaned result dataset contains no empty strings.

### related issue

Issue #1 